### PR TITLE
Fixed directory issue

### DIFF
--- a/tfswitcher-download.ps1
+++ b/tfswitcher-download.ps1
@@ -6,6 +6,7 @@ function tfswitcher-download {
       [PSDefaultValue(Help = 'amd64')]
       $cpu = "amd64"
   )
+  $getstartingpath = Get-location
     $dlver = Read-Host -Prompt "Enter the Terraform version you want to download and unzip. Example: 0.15.5 or 1.2.7"
     #$cpu = Read-Host -Prompt "386 or amd64? Please enter as 386 or amd64."
     # 0.15.5 / terraform_0.15.5_windows_386.zip    0.15.5 / terraform_0.15.5_windows_amd64.zip or 1.2.6/terraform_1.2.6_windows_386.zip"
@@ -14,4 +15,5 @@ function tfswitcher-download {
     Rename-Item "$($tfswitcherPath)terraform_$($dlver)_windows_$($cpu).zip" -NewName "$($tfswitcherPath)$($dlver).zip" -force
     Expand-Archive ".\$($dlver).zip" -force
     remove-item ".\$($dlver).zip" -force
+    cd $getstartingpath
 }


### PR DESCRIPTION
Fixed issue where after downloading a new version, the function would kick you out of your path and drop you in the tfswitcher tool path.